### PR TITLE
chore(GHA): Node.js 16 actions are deprecated.

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/workflows/setup-poetry-env
 
       - name: 'Install Task'
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -42,7 +42,7 @@ jobs:
               uses: ./.github/workflows/setup-poetry-env
 
             - name: 'Install Task'
-              uses: arduino/setup-task@v1
+              uses: arduino/setup-task@v2
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   version: 3.x

--- a/.github/workflows/setup-poetry-env/action.yml
+++ b/.github/workflows/setup-poetry-env/action.yml
@@ -15,9 +15,9 @@ runs:
         #       check-out repo and set-up python
         #----------------------------------------------
         - name: Check out repository
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: Set up python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: ${{ inputs.python-version }}
         #----------------------------------------------
@@ -34,7 +34,7 @@ runs:
         #----------------------------------------------
         - name: Load cached venv
           id: cached-poetry-dependencies
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
               path: .venv
               key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, actions/cache@v3, arduino/setup-task@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.